### PR TITLE
Accept FnMut callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refreshable"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
The implementation already ensures that there are no concurrent value updates (RefreshHandle::update takes &mut self), but due to how state is shared we need an extra Mutex around each callback.

This is a backwards compatible change since all `Fn`s are also `FnMut`s.